### PR TITLE
Replace reflection with zero value

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ func main() {
 
 ## Performance
 
-In a micro-benchmark, this library performs about half as fast as manually using the stdlib. Most likely because of the use of reflection.
+In a micro-benchmark, this library performs about 50% slower as manually using the stdlib.
 
 ```
 goos: darwin
 goarch: amd64
 pkg: github.com/mraerino/typed-context
 cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-BenchmarkStdlib-16      220490232                5.361 ns/op           0 B/op          0 allocs/op
-BenchmarkTyped-16       104538015               12.03 ns/op            0 B/op          0 allocs/op
+BenchmarkStdlib-16      205549032                5.782 ns/op           0 B/op          0 allocs/op
+BenchmarkTyped-16       123351498                8.951 ns/op           0 B/op          0 allocs/op
 PASS
-ok      github.com/mraerino/typed-context       4.336s
+ok      github.com/mraerino/typed-context       3.977s
 ```

--- a/context.go
+++ b/context.go
@@ -2,21 +2,19 @@ package typedcontext
 
 import (
 	"context"
-	"reflect"
 )
 
-type ctxKey reflect.Type
+type ctxKey interface{}
 
 func Set[T any](ctx context.Context, value T) context.Context {
-	t := reflect.TypeOf(value)
-	key := ctxKey(t)
+	var zero T
+	key := ctxKey(zero)
 	return context.WithValue(ctx, key, value)
 }
 
 func Get[T any](ctx context.Context) (val T, ok bool) {
-	t := reflect.TypeOf(val)
-	key := ctxKey(t)
-	if ctxVal := ctx.Value(key); ctxVal != nil {
+	var zero T
+	if ctxVal := ctx.Value(zero); ctxVal != nil {
 		return ctxVal.(T), true
 	}
 	return // uses zero value for T

--- a/context_test.go
+++ b/context_test.go
@@ -12,6 +12,10 @@ import (
 type Welcome string
 type RequestID string
 
+type MyStruct struct {
+	ID string
+}
+
 func TestGetSet(t *testing.T) {
 	ctx := context.Background()
 
@@ -41,6 +45,16 @@ func TestGetSet(t *testing.T) {
 	actual4, ok := typedcontext.Get[RequestID](ctx)
 	require.True(t, ok)
 	assert.Equal(t, "0c4f7d51-af18-4475-9fdc-5f022fb8079c", string(actual4))
+
+	// pointer
+	value4 := &MyStruct{
+		ID: "hello",
+	}
+	ctx = typedcontext.Set(ctx, value4)
+
+	actual5, ok := typedcontext.Get[*MyStruct](ctx)
+	require.True(t, ok)
+	assert.Equal(t, "hello", actual5.ID)
 }
 
 type ctxKey uint64


### PR DESCRIPTION
This seems to speed up things by about 30% 🥳 

```
BenchmarkStdlib-16      205549032                5.782 ns/op           0 B/op          0 allocs/op
BenchmarkTyped-16       123351498                8.951 ns/op           0 B/op          0 allocs/op
```

Thanks @rybit for the idea!