### PR TITLE
Avoid allocation from zero value

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ func main() {
 
 ## Performance
 
-In a micro-benchmark, this library performs about 50% slower as manually using the stdlib.
+In a micro-benchmark, this library performs similarly to using `context.WithValue` manually.
 
 ```
 goos: darwin
 goarch: amd64
 pkg: github.com/mraerino/typed-context
 cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
-BenchmarkStdlib-16      205549032                5.782 ns/op           0 B/op          0 allocs/op
-BenchmarkTyped-16       123351498                8.951 ns/op           0 B/op          0 allocs/op
+BenchmarkStdlib-16      203086635                5.857 ns/op           0 B/op          0 allocs/op
+BenchmarkTyped-16       194297246                6.054 ns/op           0 B/op          0 allocs/op
 PASS
-ok      github.com/mraerino/typed-context       3.977s
+ok      github.com/mraerino/typed-context       3.712s
 ```

--- a/context.go
+++ b/context.go
@@ -7,14 +7,13 @@ import (
 type ctxKey interface{}
 
 func Set[T any](ctx context.Context, value T) context.Context {
-	var zero T
-	key := ctxKey(zero)
+	key := ctxKey((*T)(nil))
 	return context.WithValue(ctx, key, value)
 }
 
 func Get[T any](ctx context.Context) (val T, ok bool) {
-	var zero T
-	if ctxVal := ctx.Value(zero); ctxVal != nil {
+	key := ctxKey((*T)(nil))
+	if ctxVal := ctx.Value(key); ctxVal != nil {
 		return ctxVal.(T), true
 	}
 	return // uses zero value for T


### PR DESCRIPTION
This brings the perf up to the same level as using manually created context keys 🎉 

I found this optimization by taking a cpuprofile from the benchmark:

```
go test -bench=BenchmarkTyped -cpuprofile=cpuprof.out
```

Then dropped that into https://www.speedscope.app/
<img width="1440" alt="Screenshot 2022-05-13 at 19 49 51" src="https://user-images.githubusercontent.com/4941459/168339784-ac8df37f-4496-406d-92d2-86f6151686c9.png">

The string allocation looked wrong and it seemed to come from creating the zero value.

Now it's matching the raw perf:

```
BenchmarkStdlib-16      203086635                5.857 ns/op           0 B/op          0 allocs/op
BenchmarkTyped-16       194297246                6.054 ns/op           0 B/op          0 allocs/op
```
